### PR TITLE
Fix checkout table transaction commit

### DIFF
--- a/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
+++ b/go/libraries/doltcore/sqle/dprocedures/dolt_checkout.go
@@ -698,7 +698,13 @@ func checkoutTablesFromHead(ctx *sql.Context, roots doltdb.Roots, name string, t
 	}
 
 	dSess := dsess.DSessFromSess(ctx.Session)
-	return dSess.SetRoots(ctx, name, roots)
+	if err = dSess.SetRoots(ctx, name, roots); err != nil {
+		return err
+	}
+	if err = commitTransaction(ctx, dSess, nil); err != nil {
+		return err
+	}
+	return nil
 }
 
 // validateNoDetachedHead checks if the given branchName refers to a tag or commit hash

--- a/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
+++ b/go/libraries/doltcore/sqle/enginetest/dolt_queries.go
@@ -3486,6 +3486,30 @@ var DoltCheckoutScripts = []queries.ScriptTest{
 			},
 		},
 	},
+	{
+		Name: "dolt_checkout multiple tables with one missing",
+		SetUpScript: []string{
+			"create table t1 (pk int primary key, c int);",
+			"call dolt_commit('-Am', 'created table');",
+			"insert into t1 values (1,1);",
+			"call dolt_commit('-am', 'add row');",
+			"insert into t1 values (2,2);",
+		},
+		Assertions: []queries.ScriptTestAssertion{
+			{
+				Query:    "select * from t1 order by 1;",
+				Expected: []sql.Row{{1, 1}, {2, 2}},
+			},
+			{
+				Query:          "call dolt_checkout('t1', 'missing');",
+				ExpectedErrStr: "tablespec 'missing' did not match any table(s) known to dolt",
+			},
+			{
+				Query:    "select * from t1 order by 1;",
+				Expected: []sql.Row{{1, 1}},
+			},
+		},
+	},
 }
 
 var DoltCheckoutReadOnlyScripts = []queries.ScriptTest{


### PR DESCRIPTION
## Summary
- commit transaction after `dSess.SetRoots` when checking out tables
- extend checkout test to confirm table contents are reset even when another table is missing

## Testing
- `go test ./... -run TestDoltCheckout -count=1` *(fails: module download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6864b7e97eac8323b3f8c1d2e84cca08